### PR TITLE
Added   the receptionist model and intergrated itinto the user

### DIFF
--- a/src/main/java/org/medcare/dao/ReceptionistDAO.java
+++ b/src/main/java/org/medcare/dao/ReceptionistDAO.java
@@ -1,0 +1,34 @@
+package org.medcare.dao;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import org.hibernate.Session;
+import org.medcare.models.Receptionist;
+import org.medcare.utils.HibernateUtil;
+
+import java.util.List;
+
+@ApplicationScoped
+public class ReceptionistDAO extends GenericDAO<Receptionist> {
+    public ReceptionistDAO() {
+        super(Receptionist.class);
+    }
+
+    // Find a Receptionist profile based on the User's ID
+    public Receptionist findByUserId(int userId) {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            return session.createQuery("FROM Receptionist r WHERE r.user.userId = :userId", Receptionist.class)
+                    .setParameter("userId", userId)
+                    .uniqueResultOptional()
+                    .orElse(null);
+        }
+    }
+
+    // Override to only find active receptionists
+    @Override
+    public List<Receptionist> findAll() {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            // Find all receptionists whose associated user account is active
+            return session.createQuery("FROM Receptionist r WHERE r.user.active = true", Receptionist.class).list();
+        }
+    }
+}

--- a/src/main/java/org/medcare/dao/UserDAO.java
+++ b/src/main/java/org/medcare/dao/UserDAO.java
@@ -9,7 +9,18 @@ import org.medcare.utils.HibernateUtil;
 public class UserDAO extends GenericDAO<User> {
     public UserDAO() { super(User.class); }
 
+    // This method is now used for login, so it MUST only find active users.
     public User findByUsername(String username) {
+        try (Session session = HibernateUtil.getSessionFactory().openSession()) {
+            return session.createQuery("FROM User WHERE username = :username AND active = true", User.class)
+                    .setParameter("username", username)
+                    .uniqueResultOptional()
+                    .orElse(null);
+        }
+    }
+
+    // New method for admin purposes to find a user regardless of active status
+    public User findByUsernameIncludeInactive(String username) {
         try (Session session = HibernateUtil.getSessionFactory().openSession()) {
             return session.createQuery("FROM User WHERE username = :username", User.class)
                     .setParameter("username", username)

--- a/src/main/java/org/medcare/models/Receptionist.java
+++ b/src/main/java/org/medcare/models/Receptionist.java
@@ -1,0 +1,43 @@
+package org.medcare.models;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+@Entity
+@Table(name = "receptionists")
+public class Receptionist {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int receptionistId;
+
+    // Link to the User account for login credentials
+    @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.EAGER)
+    @JoinColumn(name = "user_id", referencedColumnName = "userId", unique = true)
+    private User user;
+
+    @NotBlank(message = "First name is required.")
+    @Column(nullable = false)
+    private String firstName;
+
+    @NotBlank(message = "Last name is required.")
+    @Column(nullable = false)
+    private String lastName;
+
+    @NotBlank(message = "Phone number is required.")
+    @Pattern(regexp = "^(\\+256|0)7[0-9]{8}$", message = "Invalid Ugandan phone number.")
+    @Column(nullable = false)
+    private String phoneNumber;
+
+    // Getters and Setters
+    public int getReceptionistId() { return receptionistId; }
+    public void setReceptionistId(int receptionistId) { this.receptionistId = receptionistId; }
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+    public String getPhoneNumber() { return phoneNumber; }
+    public void setPhoneNumber(String phoneNumber) { this.phoneNumber = phoneNumber; }
+}

--- a/src/main/java/org/medcare/models/User.java
+++ b/src/main/java/org/medcare/models/User.java
@@ -23,18 +23,20 @@ public class User {
     @Column(nullable = false)
     private Role role;
 
+    // NEW: For soft delete functionality.
+    @Column(nullable = false)
+    private boolean active = true;
+
     // Getters and Setters
     public int getUserId() { return userId; }
-
     public String getUsername() { return username; }
     public void setUsername(String username) { this.username = username; }
-
     public String getPassword() { return password; }
     public void setPassword(String password) { this.password = password; }
-
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
-
     public Role getRole() { return role; }
     public void setRole(Role role) { this.role = role; }
+    public boolean isActive() { return active; }
+    public void setActive(boolean active) { this.active = active; }
 }


### PR DESCRIPTION
 Created/Linked User Account & Doctor Profile

Admin registers a doctor user account (with login credentials: username, password, role=DOCTOR).

Simultaneously (or in a second step), the admin fills in the doctor's profile information (e.g., specialization, contact info, department).

Doctor Updates Own Profile

Create a secured doctor view page (only accessible by doctors) where they can view and update their own profile information.

Keep user credentials separate from doctor profile fields (store them in separate tables/entities).

Admin CRUD Operations on Doctors

View: List all doctors, view detailed profiles.

Create: Create user + doctor profile as above.

Update: Update doctor’s profile or credentials.

Delete: Soft delete using an active or deleted flag.

Security and Integrity

Only allow doctors to update their own profiles. They should also be able to register and view patients and perform CRUD operations on patients.

Receptionist Flow

Admin creates the receptionist user + profile.

Admin can edit/delete (soft delete) receptionists just like doctors.

 Receptionist Profile and Permissions

Receptionist logs in, views & edits their profile.

Receptionists can register patients and doctors.

Receptionists can perform CRUD operations on doctors and patients except deletion.

✅ 7️⃣ Admin CRUD on Receptionists

Only the admin can perform CRUD operations on any doctor and receptionist (including deletion).